### PR TITLE
Restore GitHub and Instagram social links

### DIFF
--- a/src-astro/pages/index.astro
+++ b/src-astro/pages/index.astro
@@ -22,6 +22,10 @@ import BaseLayout from '../layouts/BaseLayout.astro';
             <a href="mailto:noah@noahbjohnson.net">noah@noahbjohnson.net</a>
             <span class="separator">•</span>
             <a href="https://www.linkedin.com/in/noahbjohnson" target="_blank">LinkedIn</a>
+            <span class="separator">•</span>
+            <a href="https://github.com/noahbjohnson" target="_blank">GitHub</a>
+            <span class="separator">•</span>
+            <a href="https://www.instagram.com/noahbjohnsonphotos/" target="_blank">Instagram</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Restore GitHub and Instagram links that were removed in the Astro migration.